### PR TITLE
Allow other compatible versions of python-dateutil in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-dateutil==2.4.2
+python-dateutil>=2.1,<3.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_project_path(*args):
     return os.path.abspath(os.path.join(this_dir, *args))
 
 PACKAGE_NAME = 'xplenty'
-PACKAGE_VERSION = '1.2.1'
+PACKAGE_VERSION = '1.2.2'
 PACKAGE_AUTHOR = 'Xplenty'
 PACKAGE_AUTHOR_EMAIL = 'opensource@xplenty.com'
 PACKAGE_URL = 'https://github.com/xplenty/xplenty.py'


### PR DESCRIPTION
Requiring an exact patch-level version is causing dependency resolution failures with other packages that, for example, require python-dateutil>=2.5.